### PR TITLE
Ensure modal gets removed even when animationend fails

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -2,8 +2,8 @@ import Component from '@ember/component';
 import { set } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
 import { guidFor } from '@ember/object/internals';
-import { inject as service } from '@ember/service';
 import { cancel, later } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 
 import { createFocusTrap } from 'focus-trap';
 
@@ -140,7 +140,6 @@ export default Component.extend({
 
     // make sure that we remove the modal, also resolving the test waiter
     this.modal._remove();
-
   },
 
   closeModal(result) {
@@ -154,8 +153,9 @@ export default Component.extend({
     set(this, 'animatingClass', this.outAnimationClass);
 
     const element = document.getElementById(this.modalElementId);
-    const animationDuration = window.getComputedStyle(element)['animation-duration'] ?? '0s';
-    this._timeout = later(this, 'removeModal', animationDuration.replace('s' , '') * 1000 + 1);
+    const animationDuration = window.getComputedStyle(element)['animation-duration'] ?? '0.001s';
+    const animationDurationS = parseFloat(animationDuration);
+    this._timeout = later(this, 'removeModal', animationDurationS * 1000 + 1);
 
     this.modal._resolve(result);
   },

--- a/addon/styles/ember-promise-modals.css
+++ b/addon/styles/ember-promise-modals.css
@@ -17,14 +17,14 @@
 
 @media (prefers-reduced-motion: reduce) {
   :root {
-  --epm-animation-backdrop-in-duration: 0s;
-  --epm-animation-backdrop-out-duration: 0s;
-  --epm-animation-modal-in-duration: 0s;
-  --epm-animation-modal-out-duration: 0s;
-  --epm-animation-backdrop-in-delay: 0s;
-  --epm-animation-backdrop-out-delay: 0s;
-  --epm-animation-modal-in-delay: 0s;
-  --epm-animation-modal-out-delay: 0s;
+  --epm-animation-backdrop-in-duration: 0.001s;
+  --epm-animation-backdrop-out-duration: 0.001s;
+  --epm-animation-modal-in-duration: 0.001s;
+  --epm-animation-modal-out-duration: 0.001s;
+  --epm-animation-backdrop-in-delay: 0.001s;
+  --epm-animation-backdrop-out-delay: 0.001s;
+  --epm-animation-modal-in-delay: 0.001s;
+  --epm-animation-modal-out-delay: 0.001s;
   }
 }
 


### PR DESCRIPTION
It should never happen™ but `animationend` might not trigger. I'm bringing back a timeout to ensure the modal is removed. I also use `0.001s` in place of `0s` for "no animation-duration", which should should ensure that the event triggers in the case of `reduce-motion`

Re #665