### PR TITLE
Closing the modal should inform the modals service

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -132,6 +132,9 @@ export default Component.extend({
     if (this.animatingClass !== '') {
       return;
     }
+
+    this.modals._onModalAnimationStart();
+
     // This triggers the out animation, which in turn will remove the modal after it completes
     set(this, 'animatingClass', this.outAnimationClass);
 


### PR DESCRIPTION
To be rebased & merged after #685

Before this change `epm-animating` class won't be set when _closing_ the modal, possibly making the outgoing animations potentially sluggish or wobbly.