### PR TITLE
Extract destruction of the modals effects into a method and apply them

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -27,6 +27,7 @@ export default Component.extend({
     this._super(...arguments);
 
     set(this, 'modalElementId', guidFor(this));
+
     this.modal._componentInstance = this;
 
     let { focusTrapOptions: globalFocusTrapOptions } = this.modals;
@@ -48,10 +49,7 @@ export default Component.extend({
   },
 
   willDestroyElement() {
-    // Remove the focus trap without triggering the optional onDeactivate() hook
-    this._removeFocusTrap(null);
-
-    this._removeAnimationListeners();
+    this.destroyModal();
 
     this._super(...arguments);
   },
@@ -126,6 +124,17 @@ export default Component.extend({
     }
 
     this._animationEnd = null;
+  },
+
+  destroyModal() {
+    // Remove the focus trap without triggering the optional onDeactivate() hook
+    this._removeFocusTrap(null);
+
+    // Remove the animation listeners
+    this._removeAnimationListeners();
+
+    // make sure that we remove the modal, also resolving the test waiter
+    this.modal._remove();
   },
 
   closeModal(result) {

--- a/addon/modal.js
+++ b/addon/modal.js
@@ -54,6 +54,14 @@ export default class Modal {
     return this._deferred.promise.then(onFulfilled, onRejected);
   }
 
+  _destroy() {
+    if (!this._componentInstance) {
+      return;
+    }
+
+    this._componentInstance.destroyModal();
+  }
+
   _resolve(result) {
     if (!this._deferredOutAnimation) {
       set(this, '_deferredOutAnimation', defer());

--- a/addon/services/modals.js
+++ b/addon/services/modals.js
@@ -53,7 +53,7 @@ export default Service.extend({
 
   _destroyModals() {
     this._stack.forEach(modal => {
-      modal._remove();
+      modal._destroy();
     });
   },
 


### PR DESCRIPTION
The "private" `_destroy()` method is used when the service instance is destroyed and also in the test helper to tear down any remaining modals between tests.