### PR TITLE
Prefer "happy path" code style for `_resolve()`

### DIFF
--- a/addon/modal.js
+++ b/addon/modal.js
@@ -63,17 +63,19 @@ export default class Modal {
   }
 
   _resolve(result) {
-    if (!this._deferredOutAnimation) {
-      set(this, '_deferredOutAnimation', defer());
-      if (this._options.onAnimationModalOutEnd) {
-        this._deferredOutAnimation.promise.then(() => this._options.onAnimationModalOutEnd()).catch(() => {});
-      }
-
-      this._result = result;
-      this._deferred.resolve(result);
-
-      waitForPromise(this._deferredOutAnimation.promise);
+    if (this._deferredOutAnimation) {
+      return;
     }
+
+    set(this, '_deferredOutAnimation', defer());
+    if (this._options.onAnimationModalOutEnd) {
+      this._deferredOutAnimation.promise.then(() => this._options.onAnimationModalOutEnd()).catch(() => {});
+    }
+
+    this._result = result;
+    this._deferred.resolve(result);
+
+    waitForPromise(this._deferredOutAnimation.promise);
   }
 
   _remove() {


### PR DESCRIPTION
Mostly personal preference, but potentially easier to understand. Less indentation is always a welcome bonus. 

It doesn't change behavior, but I spotted this and didn't want to foist it into one of the other PRs.
