### PR TITLE
Update ember-try configuration

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -52,11 +52,6 @@ module.exports = async function () {
           devDependencies: {
             'ember-source': await getChannelURL('release'),
           },
-          dependencies: {
-            // Will move to package.json when moving to v2 addon format
-            'ember-auto-import': '2.2.3',
-            webpack: '5.61.0',
-          },
         },
       },
       {
@@ -65,11 +60,6 @@ module.exports = async function () {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
           },
-          dependencies: {
-            // Will move to package.json when moving to v2 addon format
-            'ember-auto-import': '2.2.3',
-            webpack: '5.61.0',
-          },
         },
       },
       {
@@ -77,11 +67,6 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
-          },
-          dependencies: {
-            // Will move to package.json when moving to v2 addon format
-            'ember-auto-import': '2.2.3',
-            webpack: '5.61.0',
           },
         },
       },


### PR DESCRIPTION
The configuration held some outdated information on ember-auto-import v2 which was moved to requirements for this addon a few months ago.