### PR TITLE
setupPromiseModals should wait for test waiters to settle

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,3 +1,5 @@
+import { settled } from '@ember/test-helpers';
+
 function setMinimum(propertyName) {
   document.documentElement.style.setProperty(propertyName, '0.001s');
 }
@@ -20,7 +22,7 @@ export function setupPromiseModals(hooks) {
     this.modals = this.owner.lookup('service:modals');
   });
 
-  hooks.afterEach(function () {
+  hooks.afterEach(async function () {
     // be sure to close all modals after a test
     if (this.modals) {
       this.modals._destroyModals();
@@ -36,5 +38,8 @@ export function setupPromiseModals(hooks) {
     unsetMinimum('--epm-animation-modal-out-duration');
     unsetMinimum('--epm-animation-modal-in-delay');
     unsetMinimum('--epm-animation-modal-out-delay');
+
+    // wait for any registered test waiters to settle
+    await settled();
   });
 }

--- a/tests/application/destroy-test.js
+++ b/tests/application/destroy-test.js
@@ -1,29 +1,64 @@
-import { visit, click, settled } from '@ember/test-helpers';
+import { visit, click, settled, isSettled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+
+import { waitForPromise } from '@ember/test-waiters';
 
 import { setupPromiseModals } from 'ember-promise-modals/test-support';
 
 module('Application | destroy', function (hooks) {
   setupApplicationTest(hooks);
-  setupPromiseModals(hooks);
 
-  test('destroying the modal removes it from the DOM', async function (assert) {
-    await visit('/');
+  module('manually', function () {
+    setupPromiseModals(hooks);
 
-    assert.dom('.epm-backdrop').doesNotExist();
-    assert.dom('.epm-modal').doesNotExist();
+    test('destroying the modal removes it from the DOM', async function (assert) {
+      await visit('/');
 
-    await click('[data-test-show-modal]');
+      assert.dom('.epm-backdrop').doesNotExist();
+      assert.dom('.epm-modal').doesNotExist();
 
-    assert.dom('.epm-modal').exists();
-    assert.dom('.epm-backdrop').exists();
+      await click('[data-test-show-modal]');
 
-    this.modals._destroyModals();
+      assert.dom('.epm-modal').exists();
+      assert.dom('.epm-backdrop').exists();
 
-    await settled();
+      this.modals._destroyModals();
 
-    assert.dom('.epm-backdrop').doesNotExist();
-    assert.dom('.epm-modal').doesNotExist();
+      await settled();
+
+      assert.dom('.epm-backdrop').doesNotExist();
+      assert.dom('.epm-modal').doesNotExist();
+    });
+  });
+
+  module('when the test helper destroys the modal', function (hooks) {
+    let wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    hooks.afterEach(function (assert) {
+      assert.dom('.epm-backdrop').doesNotExist();
+      assert.dom('.epm-modal').doesNotExist();
+      assert.true(isSettled(), 'application is in settled state');
+    });
+
+    setupPromiseModals(hooks);
+
+    hooks.afterEach(async function () {
+      waitForPromise(wait(20));
+    });
+
+    test('it waits until application is settled', async function (assert) {
+      this.data = {};
+
+      await visit('/');
+
+      assert.dom('.epm-backdrop').doesNotExist();
+      assert.dom('.epm-modal').doesNotExist();
+
+      await click('[data-test-show-modal]');
+
+      assert.dom('.epm-modal').exists();
+      assert.dom('.epm-backdrop').exists();
+    });
   });
 });


### PR DESCRIPTION
Currently the `setupPromiseModals` test helper doesn't wait for the modal destruction test waiter to settle.
This might cause a race condition with other registered destructors.

By waiting for the application to settle after our modals are destroyed we are making sure the next queued destructor operates on a "clean slate"
