### PR TITLE
Drop IE 11 browser targets in test app

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };


### PR DESCRIPTION
I think this might be responsible for ember-try failures with `ember-source` `> 5.0.0`.

Was comparing this repo when investigating adopted-ember-addons/ember-file-upload/pull/941

IE 11 support was [dropped by Ember in v4](https://emberjs.com/browser-support/).