### PR TITLE
Enable analytics via Plausible

### DIFF
--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -12,6 +12,8 @@
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
+    <script defer data-domain="ember-promise-modals.com" src="https://plausible.io/js/script.js"></script>
+
     {{content-for "head-footer"}}
   </head>
   <body>


### PR DESCRIPTION
Plausible is cookie-free so no cookie banner necessary.