### PR TITLE
Fix(node support)/ Re-add node 14 to the list of supported engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "webpack": "5.90.0"
   },
   "engines": {
-    "node": "12.* || >= 16.*"
+    "node": "12.* || 14.* || >= 16.*"
   },
   "changelog": {
     "repo": "mainmatter/ember-promise-modals",


### PR DESCRIPTION
PR #858 removed node 14 from the list of supported engines after struggling with CI failures. It turns out the issues are now fixed and the CI is green when run with node 14 (this was tested in #906, and the CI was ✅).