### PR TITLE
Drop Ember < 3.28 and node < 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,9 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.4
-          - ember-lts-3.8
-          - ember-lts-3.12
           - ember-lts-3.28
+          - ember-lts-4.4
+          - ember-lts-4.8
           - ember-release
           - ember-beta
           - ember-canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 16.x
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm publish

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -36,8 +36,6 @@ export class ApplicationController extends Controller {
 
 -- [Replacing Component Helper.md](https://github.com/embroider-build/embroider/blob/main/docs/replacing-component-helper.md#when-youre-invoking-a-component-youve-been-given)
 
-## Ember < 3.28 & node < 16 support
+## Ember < 3.28
 
 The v2 addon will no longer support Ember versions lower than 3.28.
-
-Additionally, it will have dependencies such as `ember-cli-babel@8.2.0` that require node 16, so node 12 and node 14 will be removed from the supported engines.

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -35,7 +35,3 @@ export class ApplicationController extends Controller {
 > Caution: old-style components that have their template in `app/templates/components` instead of co-located next to their Javascript in `app/components` can't work correctly when discovered via their component class, because there's no way to locate the template. They should either port to being co-located (which is a simple mechanical transformation and highly recommended) or should import their own template and set it as layout as was traditional in addons before co-location was available.
 
 -- [Replacing Component Helper.md](https://github.com/embroider-build/embroider/blob/main/docs/replacing-component-helper.md#when-youre-invoking-a-component-youve-been-given)
-
-## Ember < 3.28
-
-The v2 addon will no longer support Ember versions lower than 3.28.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The better way to handle modals in your Ember.js apps.
 
 ## Compatibility
 
-- Ember.js v3.4 or above
-- Ember CLI v3.4 or above
+- Ember.js v3.28 or above
+- Ember CLI v3.28 or above
 - Node.js v16 or above
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The better way to handle modals in your Ember.js apps.
 
 - Ember.js v3.4 or above
 - Ember CLI v3.4 or above
-- Node.js v12, v14 or above
+- Node.js v16 or above
 
 ## Installation
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,44 +7,26 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.4',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.4.0',
-            '@ember/test-helpers': '2.7.0',
-            'ember-decorators-polyfill': '^1.1.5',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.8',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.8.0',
-            '@ember/test-helpers': '2.7.0',
-            'ember-decorators-polyfill': '^1.1.5',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.12',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.12.0',
-            '@ember/test-helpers': '2.7.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.28',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'jquery-integration': false,
-          }),
-        },
         npm: {
           devDependencies: {
             'ember-source': '~3.28.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.4.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.8.0',
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "webpack": "5.90.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16.*"
+    "node": ">= 16.*"
   },
   "changelog": {
     "repo": "mainmatter/ember-promise-modals",

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,5 +1,6 @@
 {
   "application-template-wrapper": false,
   "default-async-observers": true,
+  "jquery-integration": false,
   "template-only-glimmer-components": true
 }


### PR DESCRIPTION
This PR is a step of the conversion to v2 addon.

- It removes the support for Ember < 3.28
- It removes support for node < 16

**Why?**
Once the addon is converted to v2, the ember-try scenario start failing for Ember < 3.28. Also, the addon will require dependencies like `ember-cli-babel@8.2.0` (to support static blocks) that require at least node 16.

Additionally, the PR: 
- resets the `jquery-integration` to `false`.
- downgrade a node version to 16 in the CI to make sure 16 is still supported.