### PR TITLE
Fix deploy flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,12 +6,26 @@ on:
       - master
       - main
 
+env:
+  PNPM_VERSION: 8.15.1
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3.6.0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.4.0
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: pnpm
 
       - name: Install and Build 🔧
         run: |


### PR DESCRIPTION
PR #916 introduced `pnpm` command in the `deploy.yml` flow, but pnpm package manager has not been installed in the workflow. This PR adds the missing install using the exact same commands as the `ci.yml` workflow.