### PR TITLE
CI (fix): Build the addon before building and deploying the test app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,9 @@ jobs:
           node-version: 16.x
           cache: pnpm
 
+      - name: Build addon
+        run: pnpm run build:addon
+
       - name: Install and Build 🔧
         run: |
           pnpm install


### PR DESCRIPTION
The build addon step was missing from the deploy workflow of the test app.