### PR TITLE
ci (fix): in the deploy workflow, move the install before the addon build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,14 @@ jobs:
           node-version: 16.x
           cache: pnpm
 
+      - name: Install Dependencies
+        run: pnpm install
+
       - name: Build addon
         run: pnpm run build:addon
 
-      - name: Install and Build 🔧
-        run: |
-          pnpm install
-          pnpm build:test-app
+      - name: Build app 🔧
+        run: pnpm build:test-app
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.5.0


### PR DESCRIPTION
The #924 fix was done a bit in a rush. Adding the missing addon build is a thing, but we also need to install the dependencies before we can build the addon. Here the `pnpm install` was part of the "Install and Build" test-app instructions below.