### PR TITLE
Remove version numbers on private packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "version": "4.1.0",
   "private": true,
   "description": "The better way to handle modals in your Ember.js apps.",
   "repository": "https://github.com/mainmatter/ember-promise-modals",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -1,6 +1,5 @@
 {
   "name": "test-app",
-  "version": "4.1.0",
   "private": true,
   "description": "The better way to handle modals in your Ember.js apps.",
   "repository": "https://github.com/mainmatter/ember-promise-modals",


### PR DESCRIPTION
This repository is a mono-repo that contains a top-level `package.json` and two packages. The top-level package and the test-app package are `private` and are not meant to be published to `npm`. Therefore, `release-plan`, the tool we use to automate the release, doesn't update their number version (which is fundamentally useless). 

This PR removes the `version` field for `private` packages.